### PR TITLE
noble: Advertisement serviceData is an array

### DIFF
--- a/types/noble/index.d.ts
+++ b/types/noble/index.d.ts
@@ -6,6 +6,7 @@
 //                 Dan Chao <https://github.com/bioball>
 //                 Michal Lower <https://github.com/keton>
 //                 Rob Moran <https://github.com/thegecko>
+//                 Clayton Kucera <https://github.com/claytonkucera>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -65,10 +66,10 @@ export declare class Peripheral extends events.EventEmitter {
 
 export interface Advertisement {
     localName: string;
-    serviceData: {
+    serviceData: [{
         uuid: string,
         data: Buffer
-    };
+    }];
     txPowerLevel: number;
     manufacturerData: Buffer;
     serviceUuids: string[];

--- a/types/noble/noble-tests.ts
+++ b/types/noble/noble-tests.ts
@@ -45,10 +45,10 @@ var peripheral: noble.Peripheral = new noble.Peripheral();
 peripheral.uuid = "12ad4e81";
 peripheral.advertisement = {
     localName:        "device",
-    serviceData:      {
+    serviceData:      [{
         uuid: "180a",
         data: new Buffer(1)
-    },
+    }],
     txPowerLevel:     1,
     manufacturerData: new Buffer(1),
     serviceUuids:     ["0x180a", "0x180d"]


### PR DESCRIPTION
Update noble typings for Advertisement.serviceData. It should be an array of objects.

See noble source:
https://github.com/noble/noble/blob/c4cd18a7a429bb832f6c4ca793be3faf9af884e9/lib/hci-socket/gap.js#L197